### PR TITLE
`on-value` callback for `on-value` subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ _Internal detail: The values are currently cached in your app db, under the key
 `com.degel.re-frame-firebase.core\cache`. But, this is an implementation detail, subject
 to change. Please do not rely on this for anything except, perhaps, debugging._
 
+The subscription support additional keys:
+
+- `on-failure` - called when Firebase `:on` subscription error occurs (e.g. due to lack of
+                 permission to read the data)
+- `on-value` - called with the inital value and again whenever the value changes. It might
+be useful to trigger an event which will store the value in the `app-db` so it's accessible
+by event handlers.
+
 
 ## Setup
 

--- a/src/com/degel/re_frame_firebase/core.cljs
+++ b/src/com/degel/re_frame_firebase/core.cljs
@@ -69,7 +69,7 @@
          #((event->fn on-failure) %)))
 
 
-(defn firebase-on-value-sub [app-db [_ {:keys [path on-failure]}]]
+(defn firebase-on-value-sub [app-db [_ {:keys [path on-value on-failure]}]]
   (let [ref (fb-ref path)
         ;; [TODO] Potential bug alert:
         ;;        We are caching the results, keyed only by path, and we clear
@@ -83,7 +83,11 @@
         ;;        (modulo some reflection hack), since we use the id as part of
         ;;        the callback closure.
         id path
-        callback #(>evt [::on-value-handler id (js->clj-tree %)])]
+        callback (fn [value]
+                   (let [value (js->clj-tree value)]
+                     (when on-value
+                       (>evt [on-value value]))
+                     (>evt [::on-value-handler id value])))]
     (.on ref "value" callback (event->fn (or on-failure (default-error-handler))))
     (rv/make-reaction
      (fn [] (get-in @app-db [::cache id] []))


### PR DESCRIPTION
I found it useful to have ability to specify my own `on-value` callback in `on-value` subscriptions so I can plug in my event handler to sync some Firebase path with `app-db`. This way I can have an easy access to some data in other event handlers that otherwise don't have access to data from subscriptions directly.