### PR TITLE
Fixes #5: Authentication errors with redirect flow fail silently.

### DIFF
--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -17,32 +17,21 @@
      :photo-url     (.-photoURL firebase-user)
      :email         (-> firebase-user .-providerData first .-email)}))
 
-
-(defn- is-user-equal [google-user firebase-user]
-  (and
-    firebase-user
-    (some
-      #(and (= (.-providerId %) js/firebase.auth.GoogleAuthProvider.PROVIDER_ID)
-            (= (.-uid %) (.getId (.getBasicProfile google-user))))
-      (:provider-data firebase-user))))
-
-
-(defn ^:export onSignIn [google-user]
-  (when (not (is-user-equal google-user (core/current-user)))
-    (.catch
-      (.signInWithCredential
-        (js/firebase.auth)
-        (js/firebase.auth.GoogleAuthProvider.credential
-          (.-id_token (.getAuthResponse google-user))))
-      (core/default-error-handler))))
-
-
 (defn- init-auth []
   (.onAuthStateChanged
    (js/firebase.auth)
    (fn auth-state-changed [firebase-user]
      (core/set-current-user (user firebase-user)))
-   (core/default-error-handler)))
+   (core/default-error-handler))
+
+  (-> (js/firebase.auth)
+      (.getRedirectResult)
+      (.then (fn on-user-credential [user-credential]
+               (-> user-credential
+                   (.-user)
+                   (user)
+                   (core/set-current-user))))
+      (.catch (core/default-error-handler))))
 
 (def ^:private sign-in-fns
   {:popup (memfn signInWithPopup auth-provider)
@@ -51,8 +40,7 @@
 (defn- oauth-sign-in
   [auth-provider opts]
   (let [{:keys [sign-in-method scopes custom-parameters]
-         :or {sign-in-method :redirect}} opts
-        auth (js/firebase.auth.)]
+         :or {sign-in-method :redirect}} opts]
 
     (doseq [scope scopes]
       (.addScope auth-provider scope))
@@ -61,9 +49,9 @@
       (.setCustomParameters auth-provider (clj->js custom-parameters)))
 
     (if-let [sign-in (sign-in-fns sign-in-method)]
-      (.catch
-        (sign-in auth auth-provider)
-        (core/default-error-handler))
+      (-> (js/firebase.auth)
+          (sign-in auth-provider)
+          (.catch (core/default-error-handler)))
       (>evt [(core/default-error-handler)
              (js/Error. (str "Unsupported sign-in-method: " sign-in-method ". Either :redirect or :popup are supported."))]))))
 
@@ -90,6 +78,6 @@
 
 
 (defn sign-out []
-  (.catch
-   (.signOut (js/firebase.auth))
-   (core/default-error-handler)))
+  (-> (js/firebase.auth)
+      (.signOut)
+      (.catch (core/default-error-handler))))


### PR DESCRIPTION
* Added call to `firebase.auth.Auth#getRedirectResult` during initialization to handle potential errors returned redirection after authentication failure.

* Removed obsolete code.

* Small code changes for better readability.

The fix is available for testing at https://proto-app.bzdyl.net/