### PR TITLE
Adding key to push return results

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,24 @@ Example:
                       :on-success #(js/console.log "Wrote status")
                       :on-failure [:handle-failure]}}))
                       
-;;; :firebase/push is treated the same
+;;; :firebase/push is treated the same but responds with the key of the created object
+
 ```
+
+Example (diff in bold):
+
+<pre>
+(re-frame/reg-event-fx
+  :write-status
+  (fn [{db :db} [_ status]]
+    {:firebase/<b>push</b> {:path [:status]
+                      :value status
+                      :on-success #(js/console.log <b>(str "New Status push key: " %)</b> )
+                      :on-failure [:handle-failure]}}))
+</pre>
+
+> **Note:** Events will also receive the same creation key. `(rf/reg-event-fx :event-name (fn [ctx [_ key]])`
+
 
 Re-frame-firebase also supplies `:firebase/multi` to allow multiple write and/or
 pushes from a single event:

--- a/src/com/degel/re_frame_firebase/core.cljs
+++ b/src/com/degel/re_frame_firebase/core.cljs
@@ -51,16 +51,18 @@
         (str/join "/" (clj->js path))))
 
 
-(defn- firebase-write-effect [{:keys [path value on-success on-failure]}]
+(defn- setter [{:keys [path value on-success on-failure]}]
   (.set (fb-ref path)
         (clj->js value)
         (success-failure-wrapper on-success on-failure)))
 
+(def ^:private firebase-write-effect setter)
 
-(defn- firebase-push-effect [{:keys [path value on-success on-failure]}]
-  (.push (fb-ref path)
-         (clj->js value)
-         (success-failure-wrapper on-success on-failure)))
+(defn- firebase-push-effect [{:keys [path value on-success on-failure] :as all}]
+  (let [key (.-key (.push (fb-ref path)))]
+    (setter (assoc all 
+              :on-success #((event->fn on-success) key)
+              :path (conj path key)))))
 
 
 (defn- firebase-once-effect [{:keys [path on-success on-failure]}]


### PR DESCRIPTION
This pull request is to add the key to the result of pushing data into firebase. Thus when the success handler is called you can use the key to redirect the user or whatever else you need. 