### PR TITLE
Allow passing Firestore settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Initialize the library in your app initialization, probably just before you call
 
 (defn ^:export init []
   ,,,
-  (firebase/init :firebase-app-info firebase-app-info
+  (firebase/init :firebase-app-info      firebase-app-info
+                 ; See: https://firebase.google.com/docs/reference/js/firebase.firestore.Settings
+                 :firestore-settings     {:timestampsInSnapshots true}
                  :get-user-sub           [:user]
                  :set-user-event         [:set-user]
                  :default-error-handler  [:firebase-error])

--- a/examples/firestore/.gitignore
+++ b/examples/firestore/.gitignore
@@ -1,0 +1,2 @@
+/resources/public/js/
+target/

--- a/examples/firestore/project.clj
+++ b/examples/firestore/project.clj
@@ -1,10 +1,10 @@
 (defproject firestore "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript  "1.10.238"]
-                 [reagent  "0.8.0"]
+                 [reagent  "0.8.1"]
                  [re-frame "0.10.5"]
-                 [com.degel/re-frame-firebase "0.6.0-SNAPSHOT"]
-                 [com.degel/iron "0.3.0"]]
+                 [com.degel/re-frame-firebase "0.7.0"]
+                 [com.degel/iron "0.4.0"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-figwheel  "0.5.16"]]

--- a/examples/firestore/src/firestore/core.cljs
+++ b/examples/firestore/src/firestore/core.cljs
@@ -4,8 +4,16 @@
             [com.degel.re-frame-firebase :as firebase]
             [iron.re-utils :as re-utils :refer [<sub >evt event->fn sub->fn]]
             [clojure.string :as str]
-            [clojure.pprint :refer [pprint]]
-            [firestore.api-keys :as api-keys]))
+            [clojure.pprint :refer [pprint]]))
+
+;; Provide your own app info
+(defonce firebase-app-info
+  {:apiKey "MY-KEY-MY-KEY-MY-KEY-MY-KEY"
+   :authDomain "my-app.firebaseapp.com"
+   :databaseURL "https://my-app.firebaseio.com"
+   :projectId "my-app"
+   :storageBucket "my-app.appspot.com"
+   :messagingSenderId "000000000000"})
 
 ;; Global stuff
 (re-frame/reg-event-db :set-user (fn [db [_ user]] (assoc db :user user)))
@@ -159,7 +167,7 @@
 ;; Entry Point
 (defn user-info
   []
-  [:div (<sub [:user])])
+  [:div (code "clojure" (with-out-str (pprint (<sub [:user]))) "User data")])
 
 (defn ui
   []
@@ -171,7 +179,9 @@
 
 (defn ^:export run
   []
-  (firebase/init :firebase-app-info api-keys/firebase-app-info
+  (firebase/init :firebase-app-info firebase-app-info
+                 ; See: https://firebase.google.com/docs/reference/js/firebase.firestore.Settings
+                 :firestore-settings {:timestampsInSnapshots true}
                  :get-user-sub      [:user]
                  :set-user-event    [:set-user])
   (reagent/render [ui]

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -347,6 +347,7 @@
 ;;;   to handle any otherwise unhandled errors.
 ;;;
 (defn init [& {:keys [firebase-app-info
+                      firestore-settings
                       get-user-sub
                       set-user-event
                       default-error-handler]}]
@@ -354,4 +355,5 @@
                            :set-user-event        set-user-event
                            :default-error-handler default-error-handler)
   (core/initialize-app firebase-app-info)
+  (firestore/set-firestore-settings firestore-settings)
   (auth/init-auth))

--- a/src/com/degel/re_frame_firebase/firestore.cljs
+++ b/src/com/degel/re_frame_firebase/firestore.cljs
@@ -13,6 +13,10 @@
    [com.degel.re-frame-firebase.helpers :refer [promise-wrapper]]))
 
 
+(defn set-firestore-settings
+  [settings]
+  (.settings (js/firebase.firestore) (clj->js (or settings {}))))
+
 ;; Extra public functions
 (defn server-timestamp
   "Returns a field value to be used to store the server timestamp.


### PR DESCRIPTION
Right now the app will display the following warning when Firestore is used:

<img width="566" alt="screen shot 2018-08-13 at 18 26 38" src="https://user-images.githubusercontent.com/1500714/44047053-9ef64e92-9f2d-11e8-840e-64da082a2174.png">

This PR introduces another key to the `firebase/init` function where one can pass the requested [Firestore setting](https://firebase.google.com/docs/reference/js/firebase.firestore.Settings):

```clojure
(firebase/init :firebase-app-info  firebase-app-info
               :firestore-settings {:timestampsInSnapshots true}
               :get-user-sub       [:user]
               :set-user-event     [:set-user])
```

In addition to that, I've also cleaned up the Firestore example a little bit.