### PR TITLE
Phone authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,38 @@ for details how to mint such a token.
 
 ```
 
+### Phone Authentication
+
+This sends an SMS to a cellphone, to authenticate against the number. One complication is
+that a reCaptcha setup is required to avoid abuse. Only the invisible reCaptcha is implemented
+at the moment.
+
+See [Firebase docs][phone-auth] for details.
+
+[phone-auth]: https://firebase.google.com/docs/auth/web/phone-auth
+
+```clojure
+(re-frame/reg-event-fx
+ ::init-captcha
+ (fn [_ _]
+   {:firebase/init-recaptcha {:on-solve     [:msg "Welcome Human"]
+                              :container-id "sign-in-button"}}))
+
+
+(re-frame/reg-event-fx
+ ::phone-sign-in
+ (fn [_ [_ phone]]
+   {:firebase/phone-number-sign-in {:phone-number phone
+                                    :on-send      [:msg "SMS code sent"]}}))
+
+
+(re-frame/reg-event-fx
+ ::phone-confirm-code
+ (fn [_ [_ code]]
+   {:firebase/phone-number-confirm-code {:code code}}))
+
+```
+
 ### Writing to the database
 
 The firebase database is a tree. You can write values to nodes in a tree, or push them

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -143,6 +143,40 @@
 ;;; {:firebase/custom-token-sign-in {:token "eyJhbGciOiJS.."}}
 (re-frame/reg-fx :firebase/custom-token-sign-in auth/custom-token-sign-in)
 
+
+;;; Login to firebase with a phone
+;;;
+;;; Initialise recaptcha
+;;;
+;;; Accepts a map with
+;;; - :container-id - DOM id (typically the "submit phone number" button)
+;;; - :on-solve - re-frame event vector for verification (when user is verified as human)
+;;;
+;;; Example FX:
+;;; {:firebase/init-recaptcha {:container-id "sign-in-btn"
+;;;                            :on-solve     [:welcome-human]}}
+;;;
+;;; Phone number sign-in
+;;;
+;;; Accepts a map with
+;;; - :phone-number - a string in e164 format
+;;; - :on-send - an event vector for when code is sent
+;;;
+;;; Example FX:
+;;; {:firebase/phone-number-sign-in {:phonenumber "+27820000000"
+;;;                                  :on-send     [:notify-sms-sent]}}
+;;;
+;;; Confirm coe
+;;;
+;;; Accepts a map with :code, as sent in the SMS
+;;;
+;;; Example FX:
+;;; {:firebase/phone-number-confirm-code {:code "123456}}
+(re-frame/reg-fx :firebase/init-recaptcha            auth/init-recaptcha)
+(re-frame/reg-fx :firebase/phone-number-sign-in      auth/phone-number-sign-in)
+(re-frame/reg-fx :firebase/phone-number-confirm-code auth/phone-number-confirm-code)
+
+
 ;;; Logout
 ;;;
 ;;; Example FX:


### PR DESCRIPTION
As promised. Almost got all of #4 done.

A few things to note:

- I'm using the `firebase-state` atom in `core` to store the reCaptcha states. Feels more appropriate than using a global var. Hope that's OK?
- I didn't implement all the optional bells and whistles for this auth flow. (mostly to do with re-Captcha stuff). I'd rather leave that until someone want to use those.