### PR TITLE
Removing dependency on reagent

### DIFF
--- a/examples/firestore/project.clj
+++ b/examples/firestore/project.clj
@@ -1,7 +1,6 @@
 (defproject firestore "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript  "1.10.238"]
-                 [reagent  "0.8.1"]
                  [re-frame "0.10.5"]
                  [com.degel/re-frame-firebase "0.7.0"]
                  [com.degel/iron "0.4.0"]]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,6 @@
                  [org.clojure/clojurescript "1.10.339"]
                  [cljsjs/firebase "5.0.4-1"]
                  [re-frame "0.10.5"]
-                 [reagent "0.8.1"]
                  [com.degel/iron "0.4.0"]]
   :jvm-opts ^:replace ["-Xmx1g" "-server"]
   :cljsbuild {:builds {}} ; prevent https://github.com/emezeske/lein-cljsbuild/issues/413


### PR DESCRIPTION
Fixes #24 

As it stands now, reagent 0.8 and, thus, React 16 is pulled in. re-frame 10.x still depends on reagent 0.7/React 15.

Technically, this might break a project that was relying on reagent 0.8 features. This primarily involves:

- Fragments: `[:<>]` tags
- Class names as collections: `[:div {:class ["header" "header-large"]}]`
- Error boundaries. Form-3 components with the `:component-did-catch` method

But they can then just add the explicit dependency for `reagent 0.8.1` to get status quo back.