### PR TITLE
Fix syntax error in :firestore/set effect example

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,13 +410,13 @@ to the document under the `:path` argument. Also provide a clojure map represent
 the document data under the `:data` argument.
 
 ```clojure
-{:firestore/set :path [:my-collection "my-document"]
-                :data {:field1 "value1"
-                       :field2 {:inner1 "a" :inner2 "b"}}
-                :set-options {:merge false
-                              :merge-fields [:field1 [:field2 :inner1]]}
-                :on-success [:success-event]
-                :on-failure #(prn "Error:" %)}
+{:firestore/set {:path [:my-collection "my-document"]
+                 :data {:field1 "value1"
+                        :field2 {:inner1 "a" :inner2 "b"}}
+                 :set-options {:merge false
+                               :merge-fields [:field1 [:field2 :inner1]]}
+                 :on-success [:success-event]
+                 :on-failure #(prn "Error:" %)}}
 ```
 
 #### Update a document (`:firestore/update` effect)

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -206,13 +206,13 @@
 ;;; - :on-failure  Function or re-frame event vector to be dispatched.
 ;;;
 ;;; Example FX:
-;;; {:firestore/set :path [:my-collection "my-document"]
-;;;                 :data {:field1 "value1"
-;;;                        :field2 {:inner1 "a" :inner2 "b"}}
-;;;                 :set-options {:merge false
-;;;                               :merge-fields [:field1 [:field2 :inner1]]}
-;;;                 :on-success [:success-event]
-;;;                 :on-failure #(prn "Error:" %)}
+;;; {:firestore/set {:path [:my-collection "my-document"]
+;;;                  :data {:field1 "value1"
+;;;                         :field2 {:inner1 "a" :inner2 "b"}}
+;;;                  :set-options {:merge false
+;;;                                :merge-fields [:field1 [:field2 :inner1]]}
+;;;                  :on-success [:success-event]
+;;;                  :on-failure #(prn "Error:" %)}}
 ;;;
 (re-frame/reg-fx :firestore/set firestore/set-effect)
 


### PR DESCRIPTION
Fix the :firestore/set` effect example in the README.md docs (the map contained an odd number of forms, which is invalid)