### PR TITLE
:firebase/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,11 @@ See [Firebase docs][phone-auth] for details.
 
 The firebase database is a tree. You can write values to nodes in a tree, or push them
 to auto-generated unique sub-nodes of a node.  In re-frame-firebase, these are exposed
-through the `:firebase/write` and `:firebase/push` effect handlers.
+through the `:firebase/write` `:firebase/push` and  `:firebase/update` effect handlers.
 
 Each takes parameters:
 - `:path` - A vector representing a node in the firebase tree, e.g. `[:my :node]`
-- `:value` - The value to write or push
+- `:value` - The value to write or push.
 - `:on-success` - Event vector or function to call when write succeeds.
 - `:on-failure` - Event vector or function to call with the error.
 
@@ -296,6 +296,27 @@ Example (diff in bold):
 
 > **Note:** Events will also receive the same creation key. `(rf/reg-event-fx :event-name (fn [ctx [_ key]])`
 
+
+;;; :firebase/update can write to children subnodes, without overwriting children's siblings.  Use 
+;;; a clojure map of children subnode(s) and their value(s).  :firebase/write overwrites all children.
+
+```
+
+Example (diff in bold):
+
+<pre>
+(re-frame/reg-event-fx
+  :update-status
+  (fn [{db :db} [_ <b>status-children</b>]]   ;; status-children is e.g. {:life 42, :universe 42, :everything 42}
+    {:firebase/<b>update</b> {:path [:status]
+                      :value <b>status-children</b>
+                      :on-success #(js/console.log <b>"Updated status-children"</b)
+                      :on-failure [:handle-failure]}}))
+</pre>
+
+> **Note:** Multi-location updates are [atomic][multi-location-update-blogpost].
+
+[multi-location-update-blogpost]: https://firebase.googleblog.com/2015/09/introducing-multi-location-updates-and_86.html
 
 Re-frame-firebase also supplies `:firebase/multi` to allow multiple write and/or
 pushes from a single event:

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -24,6 +24,17 @@
 ;;;
 (re-frame/reg-fx :firebase/write database/write-effect)
 
+;;; Update values to Firebase.
+;;; See https://firebase.google.com/docs/reference/js/firebase.database.Reference#update
+;;;
+;;; Example FX:
+;;; {:firebase/update [:path [:my :data]
+;;;                   :value {:life 42, :universe 42, :everything 42}
+;;;                   :on-success #(prn "Write succeeded")
+;;;                   :on-failure [:firebase-error]]}
+;;;
+(re-frame/reg-fx :firebase/update database/update-effect)
+
 
 ;;; Write a value to a Firebase list.
 ;;; See https://firebase.google.com/docs/reference/js/firebase.database.Reference#push

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -72,6 +72,7 @@
    (run! (fn [[event-type args]]
            (case event-type
              :firebase/write        (database/write-effect args)
+             :firebase/update       (database/update-effect args)
              :firebase/push         (database/push-effect args)
              :firebase/read-once    (database/once-effect args)
              :firestore/delete      (firestore/delete-effect args)

--- a/src/com/degel/re_frame_firebase/database.cljs
+++ b/src/com/degel/re_frame_firebase/database.cljs
@@ -31,6 +31,13 @@
 
 (def ^:private write-effect setter)
 
+(defn- updater [{:keys [path value on-success on-failure]}]
+  (.update (fb-ref path)
+           (clj->js value)
+           (success-failure-wrapper on-success on-success)))
+
+(def ^:private update-effect updater)
+
 (defn- push-effect [{:keys [path value on-success on-failure] :as all}]
   (let [key (.-key (.push (fb-ref path)))]
     (setter (assoc all


### PR DESCRIPTION
:firebase/update can write to multiple subnodes selectively, without overwriting siblings.  Notably, multiple subnodes written with :firebase/update are written atomically.  https://firebase.googleblog.com/2015/09/introducing-multi-location-updates-and_86.html

Thank you for your consideration. 