### PR TITLE
Adding option to keywordize documents for Firestore

### DIFF
--- a/examples/firestore/src/firestore/core.cljs
+++ b/examples/firestore/src/firestore/core.cljs
@@ -174,6 +174,7 @@
   (firebase/init :firebase-app-info firebase-app-info
                  ; See: https://firebase.google.com/docs/reference/js/firebase.firestore.Settings
                  :firestore-settings {:timestampsInSnapshots true}
+                 :fs-kw? true
                  :get-user-sub      [:user]
                  :set-user-event    [:set-user])
   (reagent/render [ui]

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -384,10 +384,12 @@
                       firestore-settings
                       get-user-sub
                       set-user-event
-                      default-error-handler]}]
+                      default-error-handler
+                      fs-kw?]}]
   (core/set-firebase-state :get-user-sub          get-user-sub
                            :set-user-event        set-user-event
                            :default-error-handler default-error-handler)
   (core/initialize-app firebase-app-info)
+  (swap! core/firebase-state assoc :fs-kw? fs-kw?)
   (firestore/set-firestore-settings firestore-settings)
   (auth/init-auth))

--- a/src/com/degel/re_frame_firebase/firestore.cljs
+++ b/src/com/degel/re_frame_firebase/firestore.cljs
@@ -161,7 +161,8 @@
    (DocumentSnapshot->clj doc snapshot-options expose-objects nil))
   ([doc snapshot-options expose-objects sure-exists]
    {:data (when (or sure-exists (.-exists doc))
-            (js->clj (.data doc (clj->SnapshotOptions snapshot-options))))
+            (js->clj (.data doc (clj->SnapshotOptions snapshot-options))
+                     :keywordize-keys (:fs-kw? @core/firebase-state)))
     :id (.-id doc)
     :metadata (SnapshotMetadata->clj (.-metadata doc))
     :ref (PathReference->clj (.-ref doc))


### PR DESCRIPTION
This refers to #31 and deals with the keywordizing issue as expected. 

I'd like some input on how to handle these configurable behaviour issues. In this case, we don't want to change the existing behaviour as to not break backwards compatibility. So:

1. Is a named param provided to `init` the right way to go?
2. Where should this be stored? The goto stateful place is `core/firebase-state`. Is that fine?

I'd also like to work on a PR for #28 that would require a similar flag. So some direction would be appreciated. Once I've got some input, I'll clean this up + update docs etc.