### PR TITLE
Added support for Firebase Storage & Firebase Functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .lein-deps-sum
 .lein-plugins/
 .lein-repl-history
+.clj-kondo
+.lsp
 .repl*
 /*.iml
 /.cljs_node_repl/

--- a/README.md
+++ b/README.md
@@ -595,6 +595,28 @@ Example FX:
  ```
 
 
+### Functions
+
+[Functions](https://firebase.google.com/docs/functions) Cloud Functions for Firebase is a serverless framework that lets you automatically run backend code in response to events.
+It uses effects for call.
+
+#### Call
+Executes a Callable Firebase Cloud Function
+See: https://firebase.google.com/docs/functions/callable
+
+Required arguments: :cfn-name :data
+- :cfn-name     Cloud Function name
+- :data         Map containing request data
+- :on-success   Will be called with a clojure Map containing the response data
+- :on-error     
+
+Example FX:
+ ```clojure
+   {:functions/call {:cfn-name "my-function-name"
+                     :data {:foo "bar"} 
+                     :on-success #(js/alert (:foobar %))
+                     :on-error #(js/alert "Error: " %)}}
+ ```
 
 
 ## Examples and projects

--- a/README.md
+++ b/README.md
@@ -528,6 +528,75 @@ as it is meant to be used as a subscription.
 ```
 
 
+### Storage
+
+[Storage](https://firebase.google.com/docs/storage) Cloud Storage for Firebase is a powerful, simple, and cost-effective object storage service.  
+It uses effects for put, delete, download operations.
+
+#### Put
+Puts a collection of File objects into a Firebase Storage bucket.
+See: https://firebase.google.com/docs/storage/web/upload-files
+
+Required arguments :path :file
+
+ - :path         Path to object in the Storage bucket
+ - :file         File (https://developer.mozilla.org/en-US/docs/Web/API/File)
+ - :bucket       If not supplied, will assume the default Firebase allocated bucket
+ - :metadata     Map of metadata to set on Storage object
+ - :on-progress  Will be provided with the percentage complete
+ - :on-success   
+ - :on-error     
+
+ Example FX:
+ ```clojure
+    {:storage/put [{:path "path/to/object"
+                    :file File
+                    :metadata {:customMetadata {"some-key" "some-value"}}
+                    :on-progress #(.log js/console (str "Upload is " % "% complete."))
+                    :on-success #(js/alert "Success!")
+                    :on-error #(js/alert "Error: " %)}]}
+```
+
+#### Delete
+Deletes a collection of object paths/keys from a Firebase Storage bucket.
+See: https://firebase.google.com/docs/storage/web/delete-files
+
+Required arguments :path
+
+- :path         Path to object in the Storage bucket
+- :bucket       If not supplied, will assume the default Firebase allocated bucket
+- :on-success   
+- :on-error     
+
+Example FX:
+ ```clojure
+   {:storage/delete [{:path "path/to/object"
+                      :on-success #(js/alert "Success!")
+                      :on-error #(js/alert "Error: " %)}]}
+ ```
+
+
+#### Download URL
+Generates a url with which the browser can download an object from Firebase Storage
+See: https://firebase.google.com/docs/storage/web/download-files
+
+Required arguments: :path
+
+- :path         Path to object in the Storage bucket
+- :bucket       If not supplied, will assume the default Firebase allocated bucket
+- :on-success   Will be provided with the download url
+- :on-error     
+
+Example FX:
+ ```clojure
+   {:storage/download-url {:path "path/to/object"
+                           :on-success #(js/window.open %)
+                           :on-error #(js/alert "Error: " %)}}
+ ```
+
+
+
+
 ## Examples and projects
 
 There are examples provided in the [examples](examples) folder. It is great to

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.10.439"]
-                 [cljsjs/firebase "5.7.3-1"]
+                 [cljsjs/firebase "7.9.0-0"]
                  [re-frame "0.10.6"]
                  [com.degel/iron "0.4.0"]]
   :jvm-opts ^:replace ["-Xmx1g" "-server"]

--- a/project.clj
+++ b/project.clj
@@ -6,11 +6,11 @@
   :url "https://github.com/deg/re-frame-firebase"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.clojure/clojurescript "1.10.439"]
-                 [cljsjs/firebase "5.7.3-1"]
-                 [re-frame "0.10.6"]
-                 [com.degel/iron "0.4.0"]]
+  ;; :dependencies [[org.clojure/clojure "1.10.0"]
+                 ;; [org.clojure/clojurescript "1.10.439"]
+                 ;; [cljsjs/firebase "5.7.3-1"]
+                 ;; [re-frame "0.10.6"]
+                 ;; [com.degel/iron "0.4.0"]]
   :jvm-opts ^:replace ["-Xmx1g" "-server"]
   :cljsbuild {:builds {}} ; prevent https://github.com/emezeske/lein-cljsbuild/issues/413
   :plugins [[lein-npm "0.6.2"]]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.10.439"]
-                 [cljsjs/firebase "7.9.0-0"]
+                 [cljsjs/firebase "5.7.3-1"]
                  [re-frame "0.10.6"]
                  [com.degel/iron "0.4.0"]]
   :jvm-opts ^:replace ["-Xmx1g" "-server"]

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -11,7 +11,8 @@
    [com.degel.re-frame-firebase.core :as core]
    [com.degel.re-frame-firebase.auth :as auth]
    [com.degel.re-frame-firebase.database :as database]
-   [com.degel.re-frame-firebase.firestore :as firestore]))
+   [com.degel.re-frame-firebase.firestore :as firestore]
+   [com.degel.re-frame-firebase.storage :as storage]))
 
 ;;; Write a value to Firebase.
 ;;; See https://firebase.google.com/docs/reference/js/firebase.database.Reference#set
@@ -359,6 +360,10 @@
 ;;;   [:firestore/on-snapshot {:path-document [:my :document]}])
 ;;;
 (re-frame/reg-sub-raw :firestore/on-snapshot firestore/on-snapshot-sub)
+
+
+(re-frame/reg-fx :storage/put storage/put-effect)
+(re-frame/reg-fx :storage/delete storage/delete-effect)
 
 
 ;;; Start library and register callbacks.

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -14,7 +14,8 @@
    [com.degel.re-frame-firebase.firestore :as firestore]
    [com.degel.re-frame-firebase.storage :as storage]
    [com.degel.re-frame-firebase.functions :as functions]
-   [com.degel.re-frame-firebase.analytics :as analytics]))
+   [com.degel.re-frame-firebase.analytics :as analytics]
+   [com.degel.re-frame-firebase.app-check :as app-check]))
 
 ;;; Write a value to Firebase.
 ;;; See https://firebase.google.com/docs/reference/js/firebase.database.Reference#set
@@ -538,13 +539,20 @@
 ;;;
 (defn init [& {:keys [firebase-app-info
                       firestore-settings
+                      app-check-settings
                       get-user-sub
                       set-user-event
-                      default-error-handler]}]
+                      default-error-handler
+                      firebase-products]}]
   (core/set-firebase-state :get-user-sub          get-user-sub
                            :set-user-event        set-user-event
                            :default-error-handler default-error-handler)
   (core/initialize-app firebase-app-info)
-  (firestore/set-firestore-settings firestore-settings)
-  (analytics/init)
-  (auth/init-auth))
+  (when (firebase-products :firestore)
+    (firestore/set-firestore-settings firestore-settings))
+  (when (firebase-products :analytics)
+    (analytics/init))
+  (when (firebase-products :auth)
+    (auth/init-auth))
+  (when (firebase-products :app-check)
+    (app-check/init app-check-settings)))

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -12,7 +12,8 @@
    [com.degel.re-frame-firebase.auth :as auth]
    [com.degel.re-frame-firebase.database :as database]
    [com.degel.re-frame-firebase.firestore :as firestore]
-   [com.degel.re-frame-firebase.storage :as storage]))
+   [com.degel.re-frame-firebase.storage :as storage]
+   [com.degel.re-frame-firebase.functions :as functions]))
 
 ;;; Write a value to Firebase.
 ;;; See https://firebase.google.com/docs/reference/js/firebase.database.Reference#set
@@ -420,6 +421,25 @@
 ;;;                            :on-error #(js/alert "Error: " %)}}
 ;;;
 (re-frame/reg-fx :storage/download-url storage/download-url-effect)
+
+
+;;; Executes a Callable Firebase Cloud Function
+;;; See: https://firebase.google.com/docs/functions/callable
+;;;
+;;; Required arguments: :cfn-name :data
+;;;
+;;; - :cfn-name     Cloud Function name
+;;; - :data         Map containing request data
+;;; - :on-success   Will be called with a clojure Map containing the response data
+;;; - :on-error     
+;;;
+;;; Example FX:
+;;;    {:functions/call {:cfn-name "my-function-name"
+;;;                      :data {:foo "bar"} 
+;;;                      :on-success #(js/alert (:foobar %))
+;;;                      :on-error #(js/alert "Error: " %)}}
+;;;
+(re-frame/reg-fx :functions/call functions/call-effect)
 
 
 ;;; Start library and register callbacks.

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -176,6 +176,17 @@
 ;;;
 (re-frame/reg-fx :firebase/send-email-verification auth/send-email-verification)
 
+;;; Applies a verification code sent to the user by email
+;;;
+;;; Accepts a map with :action-code :on-success :on-error
+;;;
+;;; Example FX:
+;;; {:firebase/apply-action-code {:action-code "1234567"
+;;;                               :on-success #(js/alert "Success!")
+;;;                               :on-error #(js/alert "Error!")}}
+;;;
+(re-frame/reg-fx :firebase/apply-action-code auth/apply-action-code)
+
 ;;; Login to firebase anonymously
 ;;;
 ;;; Parameter is not used

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -13,7 +13,8 @@
    [com.degel.re-frame-firebase.database :as database]
    [com.degel.re-frame-firebase.firestore :as firestore]
    [com.degel.re-frame-firebase.storage :as storage]
-   [com.degel.re-frame-firebase.functions :as functions]))
+   [com.degel.re-frame-firebase.functions :as functions]
+   [com.degel.re-frame-firebase.analytics :as analytics]))
 
 ;;; Write a value to Firebase.
 ;;; See https://firebase.google.com/docs/reference/js/firebase.database.Reference#set
@@ -417,8 +418,8 @@
 ;;; - :bucket       If not supplied, will assume the default Firebase allocated bucket
 ;;; - :metadata     Map of metadata to set on Storage object
 ;;; - :on-progress  Will be provided with the percentage complete
-;;; - :on-success   
-;;; - :on-error     
+;;; - :on-success
+;;; - :on-error
 ;;;
 ;;; Example FX:
 ;;;    {:storage/put [{:path "path/to/object"
@@ -438,8 +439,8 @@
 ;;;
 ;;; - :path         Path to object in the Storage bucket
 ;;; - :bucket       If not supplied, will assume the default Firebase allocated bucket
-;;; - :on-success   
-;;; - :on-error     
+;;; - :on-success
+;;; - :on-error
 ;;;
 ;;; Example FX:
 ;;;    {:storage/delete [{:path "path/to/object"
@@ -457,7 +458,7 @@
 ;;; - :path         Path to object in the Storage bucket
 ;;; - :bucket       If not supplied, will assume the default Firebase allocated bucket
 ;;; - :on-success   Will be provided with the download url
-;;; - :on-error     
+;;; - :on-error
 ;;;
 ;;; Example FX:
 ;;;    {:storage/download-url {:path "path/to/object"
@@ -475,15 +476,33 @@
 ;;; - :cfn-name     Cloud Function name
 ;;; - :data         Map containing request data
 ;;; - :on-success   Will be called with a clojure Map containing the response data
-;;; - :on-error     
+;;; - :on-error
 ;;;
 ;;; Example FX:
 ;;;    {:functions/call {:cfn-name "my-function-name"
-;;;                      :data {:foo "bar"} 
+;;;                      :data {:foo "bar"}
 ;;;                      :on-success #(js/alert (:foobar %))
 ;;;                      :on-error #(js/alert "Error: " %)}}
 ;;;
 (re-frame/reg-fx :functions/call functions/call-effect)
+
+
+
+;;; Logs an event in Firebase Analytics
+;;; See: https://firebase.google.com/docs/analytics/events?authuser=0&platform=web
+;;;
+;;; Required arguments: :event :props
+;;;
+;;; - :event        Name of the event (as keyword)
+;;; - :props        Map of key/value pairs of interesting information
+;;;
+;;; Example FX:
+;;;    {:analytics/log {:event :purchase-completed
+;;;                     :props {:amount "123.45"
+;;;                             :currency "USD"}}}
+;;;
+(re-frame/reg-fx :analytics/log analytics/log-effect)
+
 
 
 ;;; Start library and register callbacks.
@@ -527,4 +546,5 @@
                            :default-error-handler default-error-handler)
   (core/initialize-app firebase-app-info)
   (firestore/set-firestore-settings firestore-settings)
+  (analytics/init)
   (auth/init-auth))

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -362,8 +362,64 @@
 (re-frame/reg-sub-raw :firestore/on-snapshot firestore/on-snapshot-sub)
 
 
+;;; Puts a collection of File objects into a Firebase Storage bucket.
+;;; See: https://firebase.google.com/docs/storage/web/upload-files
+;;;
+;;; Required arguments: :path :file
+;;;
+;;; - :path         Path to object in the Storage bucket
+;;; - :file         File (https://developer.mozilla.org/en-US/docs/Web/API/File)
+;;; - :bucket       If not supplied, will assume the default Firebase allocated bucket
+;;; - :metadata     Map of metadata to set on Storage object
+;;; - :on-progress  Will be provided with the percentage complete
+;;; - :on-success   
+;;; - :on-error     
+;;;
+;;; Example FX:
+;;;    {:storage/put [{:path "path/to/object"
+;;;                    :file File
+;;;                    :metadata {:customMetadata {"some-key" "some-value"}}
+;;;                    :on-progress #(.log js/console (str "Upload is " % "% complete."))
+;;;                    :on-success #(js/alert "Success!")
+;;;                    :on-error #(js/alert "Error: " %)}]}
+;;;
 (re-frame/reg-fx :storage/put storage/put-effect)
+
+
+;;; Deletes a collection of object paths/keys from a Firebase Storage bucket.
+;;; See: https://firebase.google.com/docs/storage/web/delete-files
+;;;
+;;; Required arguments: :path
+;;;
+;;; - :path         Path to object in the Storage bucket
+;;; - :bucket       If not supplied, will assume the default Firebase allocated bucket
+;;; - :on-success   
+;;; - :on-error     
+;;;
+;;; Example FX:
+;;;    {:storage/delete [{:path "path/to/object"
+;;;                       :on-success #(js/alert "Success!")
+;;;                       :on-error #(js/alert "Error: " %)}]}
+;;;
 (re-frame/reg-fx :storage/delete storage/delete-effect)
+
+
+;;; Generates a url with which the browser can download an object from Firebase Storage
+;;; See: https://firebase.google.com/docs/storage/web/download-files
+;;;
+;;; Required arguments: :path
+;;;
+;;; - :path         Path to object in the Storage bucket
+;;; - :bucket       If not supplied, will assume the default Firebase allocated bucket
+;;; - :on-success   Will be provided with the download url
+;;; - :on-error     
+;;;
+;;; Example FX:
+;;;    {:storage/download-url {:path "path/to/object"
+;;;                            :on-success #(js/window.open %)
+;;;                            :on-error #(js/alert "Error: " %)}}
+;;;
+(re-frame/reg-fx :storage/download-url storage/download-url-effect)
 
 
 ;;; Start library and register callbacks.

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -143,6 +143,29 @@
 (re-frame/reg-fx :firebase/email-create-user auth/email-create-user)
 
 
+;;; Updates the user's display name and profile photo URL
+;;;
+;;; Accepts a map with :profile :on-success :on-error
+;;;
+;;; Example FX:
+;;; {:firebase/update-profile {:profile {:displayName "Joe Soap"
+;;;                                      :photoURL "http://my.photo.com"}
+;;;                            :on-success #(js/alert "Success!")
+;;;                            :on-error #(js/alert "Error!")}}
+;;;
+(re-frame/reg-fx :firebase/update-profile auth/update-profile)
+
+;;; Updates the user's email address
+;;;
+;;; Accepts a map with :email :on-success :on-error
+;;;
+;;; Example FX:
+;;; {:firebase/update-email {:email "joe@soap.com"
+;;;                          :on-success #(js/alert "Success!")
+;;;                          :on-error #(js/alert "Error!")}}
+;;;
+(re-frame/reg-fx :firebase/update-email auth/update-email)
+
 ;;; Login to firebase anonymously
 ;;;
 ;;; Parameter is not used

--- a/src/com/degel/re_frame_firebase.cljs
+++ b/src/com/degel/re_frame_firebase.cljs
@@ -166,6 +166,16 @@
 ;;;
 (re-frame/reg-fx :firebase/update-email auth/update-email)
 
+;;; Send a user a verification email
+;;;
+;;; Accepts a map with :on-success :on-error
+;;;
+;;; Example FX:
+;;; {:firebase/send-email-verification {:on-success #(js/alert "Success!")
+;;;                                     :on-error #(js/alert "Error!")}}
+;;;
+(re-frame/reg-fx :firebase/send-email-verification auth/send-email-verification)
+
 ;;; Login to firebase anonymously
 ;;;
 ;;; Parameter is not used

--- a/src/com/degel/re_frame_firebase/analytics.cljs
+++ b/src/com/degel/re_frame_firebase/analytics.cljs
@@ -1,0 +1,17 @@
+(ns com.degel.re-frame-firebase.analytics
+  (:require
+  ["@firebase/analytics" :refer (getAnalytics logEvent)]
+  [com.degel.re-frame-firebase.core :as core]))
+
+(defn init
+  []
+  (swap! core/firebase-state assoc
+         :analytics (-> @core/firebase-state
+                        :app
+                        getAnalytics)))
+
+(defn log-effect
+  [{:keys [event props]} _]
+  (-> @core/firebase-state
+       :analytics
+       (logEvent (name event) (clj->js props))))

--- a/src/com/degel/re_frame_firebase/app_check.cljs
+++ b/src/com/degel/re_frame_firebase/app_check.cljs
@@ -1,0 +1,14 @@
+(ns com.degel.re-frame-firebase.app-check
+  (:require
+   ["@firebase/app-check" :refer (initializeAppCheck ReCaptchaV3Provider)]
+  [com.degel.re-frame-firebase.core :as core]))
+
+(defn init
+  [settings]
+  (when (:debug-provider settings)
+    (set! js/FIREBASE_APPCHECK_DEBUG_TOKEN true))
+  (swap! core/firebase-state assoc
+         :app-check (initializeAppCheck (:app @core/firebase-state)
+                                        (clj->js
+                                         {:provider (ReCaptchaV3Provider. (:site-key settings))
+                                          :isTokenAutoRefreshEnabled true}))))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -156,10 +156,11 @@
     (.warn js/console "reCaptcha confirmation missing")))
 
 
-(defn sign-out []
+(defn sign-out [on-success on-error]
   (-> (js/firebase.auth)
       (.signOut)
-      (.catch (core/default-error-handler))))
+      (.then on-success)
+      (.catch #(on-error (-> % js->clj .-message)))))
 
 (defn update-profile
   [{:keys [profile on-success on-error]}]

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -156,7 +156,8 @@
     (.warn js/console "reCaptcha confirmation missing")))
 
 
-(defn sign-out [on-success on-error]
+(defn sign-out 
+  [{:keys [on-success on-error]}]
   (-> (js/firebase.auth)
       (.signOut)
       (.then on-success)

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -184,3 +184,10 @@
       (.sendEmailVerification (clj->js action-code-settings))
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))
+
+(defn apply-action-code
+  [{:keys [action-code on-success on-error]}]
+  (-> (js/firebase.auth)
+      (.applyActionCode action-code)
+      (.then on-success)
+      (.catch #(on-error (-> % js->clj .-message)))))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -176,3 +176,11 @@
       (.updateEmail email)
       (.then on-success)
       (.catch on-error)))
+
+(defn send-email-verification
+  [{:keys [on-success on-error]}]
+  (-> (js/firebase.auth)
+      (.-currentUser)
+      (.sendEmailVerification)
+      (.then on-success)
+      (.catch on-error)))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -167,7 +167,7 @@
       (.-currentUser)
       (.updateProfile (clj->js profile))
       (.then on-success)
-      (.catch #(on-error (-> % js->clj .-message_)))))
+      (.catch #(on-error (-> % js->clj .-message)))))
 
 (defn update-email
   [{:keys [email on-success on-error]}]
@@ -175,7 +175,7 @@
       (.-currentUser)
       (.updateEmail email)
       (.then on-success)
-      (.catch #(on-error (-> % js->clj .-message_)))))
+      (.catch #(on-error (-> % js->clj .-message)))))
 
 (defn send-email-verification
   [{:keys [on-success on-error]}]
@@ -183,4 +183,4 @@
       (.-currentUser)
       (.sendEmailVerification)
       (.then on-success)
-      (.catch #(on-error (-> % js->clj .-message_)))))
+      (.catch #(on-error (-> % js->clj .-message)))))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -181,6 +181,6 @@
   [{:keys [action-code-settings on-success on-error]}]
   (-> (js/firebase.auth)
       (.-currentUser)
-      (.sendEmailVerification action-code-settings)
+      (.sendEmailVerification (clj->js action-code-settings))
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -175,7 +175,7 @@
       (.-currentUser)
       (.updateEmail email)
       (.then on-success)
-      (.catch on-error)))
+      (.catch #(on-error (-> % js->clj .-message_)))))
 
 (defn send-email-verification
   [{:keys [on-success on-error]}]
@@ -183,4 +183,4 @@
       (.-currentUser)
       (.sendEmailVerification)
       (.then on-success)
-      (.catch on-error)))
+      (.catch #(on-error (-> % js->clj .-message_)))))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -178,9 +178,9 @@
       (.catch #(on-error (-> % js->clj .-message)))))
 
 (defn send-email-verification
-  [{:keys [on-success on-error]}]
+  [{:keys [action-code-settings on-success on-error]}]
   (-> (js/firebase.auth)
       (.-currentUser)
-      (.sendEmailVerification)
+      (.sendEmailVerification action-code-settings)
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -8,7 +8,8 @@
    [re-frame.core :as re-frame]
    [iron.re-utils :refer [>evt]]
    [com.degel.re-frame-firebase.core :as core]
-   ["@firebase/auth" :refer (getAuth onAuthStateChanged getRedirectResult updateProfile)]))
+   ["@firebase/auth" :refer (getAuth onAuthStateChanged getRedirectResult updateProfile
+                                     sendEmailVerification applyActionCode updateEmail)]))
 
 
 (defn- user
@@ -174,7 +175,7 @@
   [{:keys [email on-success on-error]}]
   (-> (getAuth)
       (.-currentUser)
-      (.updateEmail email)
+      (updateEmail email)
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))
 
@@ -182,13 +183,13 @@
   [{:keys [action-code-settings on-success on-error]}]
   (-> (getAuth)
       (.-currentUser)
-      (.sendEmailVerification (clj->js action-code-settings))
+      (sendEmailVerification (clj->js action-code-settings))
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))
 
 (defn apply-action-code
   [{:keys [action-code on-success on-error]}]
   (-> (getAuth)
-      (.applyActionCode action-code)
+      (applyActionCode action-code)
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -160,3 +160,19 @@
   (-> (js/firebase.auth)
       (.signOut)
       (.catch (core/default-error-handler))))
+
+(defn update-profile
+  [{:keys [profile on-success on-error]}]
+  (-> (js/firebase.auth)
+      (.-currentUser)
+      (.updateProfile (clj->js profile))
+      (.then on-success)
+      (.catch on-error)))
+
+(defn update-email
+  [{:keys [email on-success on-error]}]
+  (-> (js/firebase.auth)
+      (.-currentUser)
+      (.updateEmail email)
+      (.then on-success)
+      (.catch on-error)))

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -167,7 +167,7 @@
       (.-currentUser)
       (.updateProfile (clj->js profile))
       (.then on-success)
-      (.catch on-error)))
+      (.catch #(on-error (-> % js->clj .-message_)))))
 
 (defn update-email
   [{:keys [email on-success on-error]}]

--- a/src/com/degel/re_frame_firebase/auth.cljs
+++ b/src/com/degel/re_frame_firebase/auth.cljs
@@ -7,9 +7,8 @@
    [clojure.spec.alpha :as s]
    [re-frame.core :as re-frame]
    [iron.re-utils :refer [>evt]]
-   [firebase.app :as firebase-app]
-   [firebase.auth :as firebase-auth]
-   [com.degel.re-frame-firebase.core :as core]))
+   [com.degel.re-frame-firebase.core :as core]
+   ["@firebase/auth" :refer (getAuth onAuthStateChanged getRedirectResult updateProfile)]))
 
 
 (defn- user
@@ -31,18 +30,18 @@
       (core/set-current-user)))
 
 (defn- init-auth []
-  (.onAuthStateChanged
-   (js/firebase.auth)
-   set-user
-   (core/default-error-handler))
 
-  (-> (js/firebase.auth)
-      (.getRedirectResult)
+  (onAuthStateChanged (getAuth) set-user (core/default-error-handler))
+
+  (-> (getAuth)
+      getRedirectResult
       (.then (fn on-user-credential [user-credential]
-               (-> user-credential
-                   (.-user)
-                   set-user)))
+               (when user-credential
+                 (-> user-credential
+                     (.-user)
+                     set-user))))
       (.catch (core/default-error-handler))))
+
 
 (def ^:private sign-in-fns
   {:popup (memfn signInWithPopup auth-provider)
@@ -62,13 +61,13 @@
          :or {sign-in-method :redirect}} opts]
 
     (doseq [scope scopes]
-      (.addScope auth-provider scope))
+      (.addScope ^js auth-provider scope))
 
     (when custom-parameters
-      (.setCustomParameters auth-provider (clj->js custom-parameters)))
+      (.setCustomParameters ^js auth-provider (clj->js custom-parameters)))
 
     (if-let [sign-in (sign-in-fns sign-in-method)]
-      (-> (js/firebase.auth)
+      (-> (getAuth)
           (sign-in auth-provider)
           (.then (partial maybe-link-with-credential link-with-credential))
           (.catch (core/default-error-handler)))
@@ -98,28 +97,28 @@
 
 
 (defn email-sign-in [{:keys [email password]}]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.signInWithEmailAndPassword email password)
       (.then set-user)
       (.catch (core/default-error-handler))))
 
 
 (defn email-create-user [{:keys [email password]}]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.createUserWithEmailAndPassword email password)
       (.then set-user)
       (.catch (core/default-error-handler))))
 
 
 (defn anonymous-sign-in [opts]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.signInAnonymously)
       (.then set-user)
       (.catch (core/default-error-handler))))
 
 
 (defn custom-token-sign-in [{:keys [token]}]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.signInWithCustomToken token)
       (.then set-user)
       (.catch (core/default-error-handler))))
@@ -136,7 +135,7 @@
 
 (defn phone-number-sign-in [{:keys [phone-number on-send]}]
   (if-let [verifier (:recaptcha-verifier @core/firebase-state)]
-    (-> (js/firebase.auth)
+    (-> (getAuth)
         (.signInWithPhoneNumber phone-number verifier)
         (.then (fn [confirmation]
                  (when on-send
@@ -156,24 +155,24 @@
     (.warn js/console "reCaptcha confirmation missing")))
 
 
-(defn sign-out 
+(defn sign-out
   [{:keys [on-success on-error]}]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.signOut)
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))
 
 (defn update-profile
   [{:keys [profile on-success on-error]}]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.-currentUser)
-      (.updateProfile (clj->js profile))
+      (updateProfile (clj->js profile))
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))
 
 (defn update-email
   [{:keys [email on-success on-error]}]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.-currentUser)
       (.updateEmail email)
       (.then on-success)
@@ -181,7 +180,7 @@
 
 (defn send-email-verification
   [{:keys [action-code-settings on-success on-error]}]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.-currentUser)
       (.sendEmailVerification (clj->js action-code-settings))
       (.then on-success)
@@ -189,7 +188,7 @@
 
 (defn apply-action-code
   [{:keys [action-code on-success on-error]}]
-  (-> (js/firebase.auth)
+  (-> (getAuth)
       (.applyActionCode action-code)
       (.then on-success)
       (.catch #(on-error (-> % js->clj .-message)))))

--- a/src/com/degel/re_frame_firebase/core.cljs
+++ b/src/com/degel/re_frame_firebase/core.cljs
@@ -4,7 +4,7 @@
 (ns com.degel.re-frame-firebase.core
   (:require
    [iron.re-utils :refer [<sub >evt event->fn sub->fn]]
-   [firebase.app :as firebase-app]))
+   ["@firebase/app" :refer (initializeApp)]))
 
 ;;; Used mostly to register client handlers
 (defonce firebase-state (atom {}))
@@ -16,7 +16,8 @@
          :default-error-handler (event->fn (or default-error-handler js/alert))))
 
 (defn initialize-app [firebase-app-info]
-  (js/firebase.initializeApp (clj->js firebase-app-info)))
+  (swap! firebase-state assoc
+         :app (initializeApp (clj->js firebase-app-info))))
 
 ;;; [TODO] Consider adding a default atom to hold the user state when :get-user-fn and
 ;;; and :set-user-fn are not defined. Need to do this carefully, so as not to cause any

--- a/src/com/degel/re_frame_firebase/database.cljs
+++ b/src/com/degel/re_frame_firebase/database.cljs
@@ -10,8 +10,6 @@
    [reagent.ratom :as ratom :refer [make-reaction]]
    [iron.re-utils :refer [<sub >evt event->fn sub->fn]]
    [iron.utils :as utils]
-   [firebase.app :as firebase-app]
-   [firebase.database :as firebase-database]
    [com.degel.re-frame-firebase.helpers :refer [js->clj-tree success-failure-wrapper]]
    [com.degel.re-frame-firebase.core :as core]
    [com.degel.re-frame-firebase.specs :as specs]))

--- a/src/com/degel/re_frame_firebase/firestore.cljs
+++ b/src/com/degel/re_frame_firebase/firestore.cljs
@@ -9,7 +9,7 @@
    [com.degel.re-frame-firebase.core :as core]
    [com.degel.re-frame-firebase.specs :as specs]
    [com.degel.re-frame-firebase.helpers :refer [promise-wrapper]]
-   ["@firebase/firestore" :refer (initializeFirestore DocumentReference doc getDoc collection CollectionReference getDocs onSnapshot setDoc)]))
+   ["@firebase/firestore" :refer (initializeFirestore DocumentReference doc getDoc collection CollectionReference getDocs onSnapshot setDoc FieldPath)]))
 
 
 (defn set-firestore-settings
@@ -87,9 +87,9 @@
   [field-path]
   (cond
     (nil? field-path) nil
-    (instance? js/firebase.firestore.FieldPath field-path) field-path
+    (instance? FieldPath field-path) field-path
     (coll? field-path) (apply js/firebase.firestore.FieldPath. (clj->js field-path))
-    :else (js/firebase.firestore.FieldPath. (clj->js field-path))))
+    :else (FieldPath. (clj->js field-path))))
 
 (defn clj->SetOptions
   "Converts a clojure-style map into a SetOptions satisfying one.
@@ -281,7 +281,7 @@
 (defn- query [ref where order-by limit
               start-at start-after end-at end-before]
   (as-> ref $
-    (if where
+    #_(if where
       (reduce
         (fn [$$ [field-path op value]] (.where $$ (clj->FieldPath field-path) (clj->js op) (clj->js value)))
         $ where)

--- a/src/com/degel/re_frame_firebase/firestore.cljs
+++ b/src/com/degel/re_frame_firebase/firestore.cljs
@@ -6,16 +6,17 @@
    [reagent.ratom :as ratom :refer [make-reaction]]
    [iron.re-utils :as re-utils :refer [<sub >evt event->fn sub->fn]]
    [iron.utils :as utils]
-   [firebase.app :as firebase-app]
-   [firebase.firestore :as firebase-firestore]
    [com.degel.re-frame-firebase.core :as core]
    [com.degel.re-frame-firebase.specs :as specs]
-   [com.degel.re-frame-firebase.helpers :refer [promise-wrapper]]))
+   [com.degel.re-frame-firebase.helpers :refer [promise-wrapper]]
+   ["@firebase/firestore" :refer (initializeFirestore DocumentReference doc getDoc collection CollectionReference getDocs onSnapshot setDoc)]))
 
 
 (defn set-firestore-settings
   [settings]
-  (.settings (js/firebase.firestore) (clj->js (or settings {}))))
+  (swap! core/firebase-state assoc
+         :firestore (initializeFirestore (:app @core/firebase-state)
+                                         (clj->js (or settings {})))))
 
 ;; Extra public functions
 (defn server-timestamp
@@ -51,7 +52,7 @@
   {:firestore/get {:path-collection [:my-collection]
                    :where [[(document-id-field-path) :>= \"start\"]]}}"
   []
-  (.documentId firebase.firestore.FieldPath))
+  (.documentId js/firebase.firestore.FieldPath))
 
 
 ;; Type Conversion/Parsing
@@ -61,9 +62,9 @@
   See https://firebase.google.com/docs/reference/js/firebase.firestore.CollectionReference"
   [path]
   {:pre [(utils/validate ::specs/path-collection path)]}
-  (if (instance? js/firebase.firestore.CollectionReference path)
+  (if (instance? CollectionReference path)
     path
-    (.collection (js/firebase.firestore)
+    (collection (:firestore @core/firebase-state)
                  (str/join "/" (clj->js path)))))
 
 (defn clj->DocumentReference
@@ -72,10 +73,10 @@
   See https://firebase.google.com/docs/reference/js/firebase.firestore.DocumentReference"
   [path]
   {:pre [(utils/validate ::specs/path-document path)]}
-  (if (instance? js/firebase.firestore.DocumentReference path)
+  (if (instance? DocumentReference path)
     path
-    (.doc (js/firebase.firestore)
-          (str/join "/" (clj->js path)))))
+    (doc (:firestore @core/firebase-state)
+         (str/join "/" (clj->js path)))))
 
 (defn clj->FieldPath
   "Converts a string/keyword or a seq of string/keywords into a FieldPath.
@@ -234,11 +235,11 @@
 ;; re-frame Effects/Subscriptions
 (defn- setter
   ([path data set-options]
-   (.set (clj->DocumentReference path)
+   (setDoc (clj->DocumentReference path)
          (clj->js data)
          (clj->SetOptions set-options)))
   ([instance path data set-options]
-   (.set instance
+   (setDoc instance
          (clj->DocumentReference path)
          (clj->js data)
          (clj->SetOptions set-options))))
@@ -297,11 +298,11 @@
     (if end-before (.apply (.-endBefore $) $ (clj->js end-before)) $)))
 
 (defn- getter-document [path get-options]
-  (.get (clj->DocumentReference path) (clj->GetOptions get-options)))
+  (getDoc (clj->DocumentReference path) (clj->GetOptions get-options)))
 
 (defn- getter-collection [path get-options where order-by limit
                           start-at start-after end-at end-before]
-  (.get (query (clj->CollectionReference path) where order-by limit
+  (getDocs (query (clj->CollectionReference path) where order-by limit
                start-at start-after end-at end-before)
         (clj->GetOptions get-options)))
 
@@ -322,7 +323,7 @@
                      on-failure)))
 
 (defn- on-snapshotter [reference-or-query snapshot-listen-options on-next on-error register-listener]
-  (-> (.onSnapshot reference-or-query
+  (-> (onSnapshot reference-or-query
                    (clj->SnapshotListenOptions snapshot-listen-options)
                    on-next
                    (if on-error (event->fn on-error) (core/default-error-handler)))

--- a/src/com/degel/re_frame_firebase/functions.cljs
+++ b/src/com/degel/re_frame_firebase/functions.cljs
@@ -1,11 +1,15 @@
 (ns com.degel.re-frame-firebase.functions
   (:require
-   [firebase.functions :as firebase-functions]
-   [clojure.walk :as w]))
+   [clojure.walk :as w]
+   [com.degel.re-frame-firebase.core :as core]
+   ["@firebase/functions" :refer (httpsCallable getFunctions)]))
 
 (defn call-effect [options]
   (let [{:keys [cfn-name data on-success on-error]} options
-        cfn (.httpsCallable (.functions js/firebase) cfn-name)]
+        cfn (-> @core/firebase-state
+                :app
+                getFunctions
+                (httpsCallable cfn-name))]
     (.catch
      (.then
       (cfn (clj->js data))
@@ -13,4 +17,3 @@
                        js->clj
                        w/keywordize-keys)))
      #(on-error %))))
-

--- a/src/com/degel/re_frame_firebase/functions.cljs
+++ b/src/com/degel/re_frame_firebase/functions.cljs
@@ -1,0 +1,16 @@
+(ns com.degel.re-frame-firebase.functions
+  (:require
+   [firebase.functions :as firebase-functions]
+   [clojure.walk :as w]))
+
+(defn call-effect [options]
+  (let [{:keys [cfn-name data on-success on-error]} options
+        cfn (.httpsCallable (.functions js/firebase) cfn-name)]
+    (.catch
+     (.then
+      (cfn (clj->js data))
+      #(on-success (-> (.. % -data)
+                       js->clj
+                       w/keywordize-keys)))
+     #(on-error %))))
+

--- a/src/com/degel/re_frame_firebase/helpers.cljs
+++ b/src/com/degel/re_frame_firebase/helpers.cljs
@@ -14,7 +14,7 @@
 ;;; with them.
 
 
-(defn js->clj-tree [x]
+(defn js->clj-tree [^js x]
   (-> (.val x)
       js->clj
       clojure.walk/keywordize-keys))

--- a/src/com/degel/re_frame_firebase/storage.cljs
+++ b/src/com/degel/re_frame_firebase/storage.cljs
@@ -35,19 +35,25 @@
   (promise-wrapper (.getDownloadURL (-> (.ref (get-storage bucket))
                                         (.child path)))
                    on-success
-                   on-error))
+                   #(on-error (-> % js->clj .-message_))))
 
 (defn put-effect [items _]
   (doseq [item items]
     (let [{:keys [path file metadata on-success on-error on-progress bucket]} item]
       (put path file
            (clj->js metadata)
-           on-success on-error on-progress bucket))))
+           on-success 
+           #(on-error (-> % js->clj .-message_)) 
+           on-progress 
+           bucket))))
 
 (defn delete-effect [items _]
   (doseq [item items]
     (let [{:keys [path on-success on-error bucket]} item]
-      (delete path on-success on-error bucket))))
+      (delete path
+              on-success
+              #(on-error (-> % js->clj .-message_))
+              bucket))))
 
 
 

--- a/src/com/degel/re_frame_firebase/storage.cljs
+++ b/src/com/degel/re_frame_firebase/storage.cljs
@@ -1,0 +1,57 @@
+(ns com.degel.re-frame-firebase.storage
+  (:require
+   [firebase.storage :as firebase-storage]))
+
+(defn get-storage [bucket]
+  (if bucket
+    (.storage (.app js/firebase) (str "gs://" bucket))
+    (js/firebase.storage)))                                 ;default firebase bucket
+
+(defn put
+  ([path file metadata on-success on-error]
+   (put path file metadata on-success on-error nil))
+  ([path file metadata on-success on-error bucket]
+   (let [upload-task (.put (-> (.ref (get-storage bucket))
+                               (.child path))
+                           file metadata)]
+     (.on
+      upload-task
+      "state_changed"
+      #(let [progress (* (/ (.-bytesTransferred %) (.-totalBytes %)) 100)]
+         (.log js/console (str "Upload is " progress)))
+      #(on-error %)
+      #(on-success)))))
+
+(defn delete
+  ([key on-success on-error]
+   (delete key on-success on-error nil))
+  ([key on-success on-error bucket]
+   (.then (.delete (-> (.ref (get-storage bucket))
+                       (.child key)))
+          on-success
+          on-error)))
+
+(defn download-url
+  ([key on-success on-error]
+   (download-url key on-success on-error nil))
+  ([key on-success on-error bucket]
+   (.then (.getDownloadURL (-> (.ref (get-storage bucket))
+                               (.child key)))
+          on-success
+          on-error)))
+
+(defn put-effect [items _]
+  (doseq [item items]
+    (let [{:keys [file metadata on-success on-error]} item]
+      (put (key file) (val file)
+           (clj->js metadata)
+           on-success on-error))))
+
+(defn delete-effect [items _]
+  (doseq [item items]
+    (let [{:keys [file on-success on-error]} item]
+      (delete (key file) on-success on-error))))
+
+
+
+

--- a/src/com/degel/re_frame_firebase/storage.cljs
+++ b/src/com/degel/re_frame_firebase/storage.cljs
@@ -1,56 +1,53 @@
 (ns com.degel.re-frame-firebase.storage
   (:require
-   [firebase.storage :as firebase-storage]))
+   [firebase.storage :as firebase-storage]
+   [com.degel.re-frame-firebase.helpers :refer [promise-wrapper]]))
 
-(defn get-storage [bucket]
+(defn- get-storage [bucket]
   (if bucket
     (.storage (.app js/firebase) (str "gs://" bucket))
     (js/firebase.storage)))                                 ;default firebase bucket
 
-(defn put
-  ([path file metadata on-success on-error]
-   (put path file metadata on-success on-error nil))
-  ([path file metadata on-success on-error bucket]
-   (let [upload-task (.put (-> (.ref (get-storage bucket))
-                               (.child path))
-                           file metadata)]
-     (.on
-      upload-task
-      "state_changed"
-      #(let [progress (* (/ (.-bytesTransferred %) (.-totalBytes %)) 100)]
-         (.log js/console (str "Upload is " progress)))
-      #(on-error %)
-      #(on-success)))))
+(defn- put [path file metadata on-success on-error on-progress bucket]
+  (let [upload-task (.put (-> (.ref (get-storage bucket))
+                              (.child path))
+                          file metadata)]
+    (.on
+     upload-task
+     "state_changed"
+     #(if on-progress
+        (on-progress (* (/ (.-bytesTransferred %) (.-totalBytes %)) 100))
+        (fn []))
+     #(if on-error
+        (on-error %)
+        (fn []))
+     #(if on-success
+        (on-success)
+        (fn [])))))
 
-(defn delete
-  ([key on-success on-error]
-   (delete key on-success on-error nil))
-  ([key on-success on-error bucket]
-   (.then (.delete (-> (.ref (get-storage bucket))
-                       (.child key)))
-          on-success
-          on-error)))
+(defn- delete [path on-success on-error bucket]
+  (promise-wrapper (.delete (-> (.ref (get-storage bucket))
+                                (.child path)))
+                   on-success
+                   on-error))
 
-(defn download-url
-  ([key on-success on-error]
-   (download-url key on-success on-error nil))
-  ([key on-success on-error bucket]
-   (.then (.getDownloadURL (-> (.ref (get-storage bucket))
-                               (.child key)))
-          on-success
-          on-error)))
+(defn download-url-effect [{:keys [path on-success on-error bucket]}]
+  (promise-wrapper (.getDownloadURL (-> (.ref (get-storage bucket))
+                                        (.child path)))
+                   on-success
+                   on-error))
 
 (defn put-effect [items _]
   (doseq [item items]
-    (let [{:keys [file metadata on-success on-error]} item]
-      (put (key file) (val file)
+    (let [{:keys [path file metadata on-success on-error on-progress bucket]} item]
+      (put path file
            (clj->js metadata)
-           on-success on-error))))
+           on-success on-error on-progress bucket))))
 
 (defn delete-effect [items _]
   (doseq [item items]
-    (let [{:keys [file on-success on-error]} item]
-      (delete (key file) on-success on-error))))
+    (let [{:keys [path on-success on-error bucket]} item]
+      (delete path on-success on-error bucket))))
 
 
 


### PR DESCRIPTION
Thank you for this library, I find it extremely useful.

Currently you have wrappers for Firebase Authentication, Realtime Database & FireStore

I thought it useful to include basic operations of [Firebase Storage](https://firebase.google.com/docs/storage) and [Firebase Functions](https://firebase.google.com/docs/functions) submitted via this Pull Request.

### Storage
re-frame effects are implemented for basic Storage functions put, delete & download-url

#### Put
Puts a collection of File objects into a Firebase Storage bucket.
See: https://firebase.google.com/docs/storage/web/upload-files

Required arguments :path :file

 - :path         Path to object in the Storage bucket
 - :file         File (https://developer.mozilla.org/en-US/docs/Web/API/File)
 - :bucket       If not supplied, will assume the default Firebase allocated bucket
 - :metadata     Map of metadata to set on Storage object
 - :on-progress  Will be provided with the percentage complete
 - :on-success   
 - :on-error     

 Example FX:
 ```clojure
    {:storage/put [{:path "path/to/object"
                    :file File
                    :metadata {:customMetadata {"some-key" "some-value"}}
                    :on-progress #(.log js/console (str "Upload is " % "% complete."))
                    :on-success #(js/alert "Success!")
                    :on-error #(js/alert "Error: " %)}]}
```

#### Delete
Deletes a collection of object paths/keys from a Firebase Storage bucket.
See: https://firebase.google.com/docs/storage/web/delete-files

Required arguments :path

- :path         Path to object in the Storage bucket
- :bucket       If not supplied, will assume the default Firebase allocated bucket
- :on-success   
- :on-error     

Example FX:
 ```clojure
   {:storage/delete [{:path "path/to/object"
                      :on-success #(js/alert "Success!")
                      :on-error #(js/alert "Error: " %)}]}
 ```


#### Download URL
Generates a url with which the browser can download an object from Firebase Storage
See: https://firebase.google.com/docs/storage/web/download-files

Required arguments: :path

- :path         Path to object in the Storage bucket
- :bucket       If not supplied, will assume the default Firebase allocated bucket
- :on-success   Will be provided with the download url
- :on-error     

Example FX:
 ```clojure
   {:storage/download-url {:path "path/to/object"
                           :on-success #(js/window.open %)
                           :on-error #(js/alert "Error: " %)}}
 ```

### Functions
re-frame effects are implemented for basic Functions of call

#### Call
Executes a Callable Firebase Cloud Function
See: https://firebase.google.com/docs/functions/callable

Required arguments: :cfn-name :data
- :cfn-name     Cloud Function name
- :data         Map containing request data
- :on-success   Will be called with a clojure Map containing the response data
- :on-error     

Example FX:
 ```clojure
   {:functions/call {:cfn-name "my-function-name"
                     :data {:foo "bar"} 
                     :on-success #(js/alert (:foobar %))
                     :on-error #(js/alert "Error: " %)}}
 ```


